### PR TITLE
add config cmds

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -1,0 +1,25 @@
+name: Run Build Tests
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Build Tools
+        run: |
+          python -m pip install build wheel
+      - name: Build Distribution Packages
+        run: |
+          python setup.py bdist_wheel
+      - name: Install package
+        run: |
+          pip install .

--- a/hmcli/config/__init__.py
+++ b/hmcli/config/__init__.py
@@ -1,0 +1,1 @@
+from . import cfg

--- a/hmcli/config/cfg.py
+++ b/hmcli/config/cfg.py
@@ -1,0 +1,107 @@
+from os import makedirs
+from os.path import isdir
+from pprint import pprint
+
+import click
+from json_database import JsonStorageXDG
+
+from .cmd_group import config_cmds
+
+CONFIGURATION = JsonStorageXDG("HivemindCore")
+
+
+@click.command("set-loop", help="set event loop backend (asyncio vs twisted)")
+@click.option('--backend', type=click.Choice(['asyncio', 'twisted']), required=True)
+def set_loop(backend):
+    if backend == "twisted":
+        CONFIGURATION["twisted"] = True
+    else:
+        CONFIGURATION["twisted"] = False
+    CONFIGURATION.store()
+
+
+@click.command("set-port", help="set hivemind listener port")
+@click.option('--port', type=int, required=True)
+def set_port(port):
+    CONFIGURATION["port"] = port
+    CONFIGURATION.store()
+
+
+@click.command("set-cert-path", help="set path to look for ssl certificates")
+@click.option('--path', type=str, required=True)
+def set_cert(path):
+    CONFIGURATION["ssl"]["certificates"] = path
+    if not isdir(CONFIGURATION["ssl"]["certificates"]):
+        makedirs(CONFIGURATION["ssl"]["certificates"])
+
+    CONFIGURATION.store()
+
+
+@click.command("set-cert-file", help="set filename for ssl certificate, default HiveMind.crt")
+@click.option('--name', type=str, required=True)
+def set_cert_file(name):
+    CONFIGURATION["ssl"]["certificates"]['ssl_certfile'] = name
+    CONFIGURATION.store()
+
+
+@click.command("set-cert-key", help="set filename for ssl certificate, default HiveMind.key")
+@click.option('--name', type=str, required=True)
+def set_cert_key(name):
+    CONFIGURATION["ssl"]["certificates"]['ssl_keyfile'] = name
+    CONFIGURATION.store()
+
+
+@click.command("enable-ssl", help="Enable wss:// (secure)")
+def enable_ssl():
+    CONFIGURATION["ssl"]["enabled"] = True
+    CONFIGURATION.store()
+
+
+@click.command("disable-ssl", help="Disable wss:// (insecure)")
+def disable_ssl():
+    CONFIGURATION["ssl"]["enabled"] = False
+    CONFIGURATION.store()
+
+
+@click.command("require-crypto", help="require AES encryption, connections will be refused if key is missing")
+def require_crypto():
+    CONFIGURATION["crypto"]["required"] = True
+    CONFIGURATION.store()
+
+
+@click.command("optional-crypto", help="optional AES encryption, default to plain text messages")
+def optional_crypto():
+    CONFIGURATION["crypto"]["required"] = False
+    CONFIGURATION.store()
+
+
+@click.command("enable-handshake", help="Enable automatic crypto key negotiation")
+def enable_handshakes():
+    CONFIGURATION["crypto"]["handshake"] = True
+    CONFIGURATION.store()
+
+
+@click.command("disable-handshake", help="Disable automatic crypto key negotiation")
+def disable_handshakes():
+    CONFIGURATION["crypto"]["handshake"] = False
+    CONFIGURATION.store()
+
+
+@click.command("print", help="print json config")
+def printcfg():
+    CONFIGURATION["ssl"]["enabled"] = False
+    pprint(CONFIGURATION)
+
+
+config_cmds.add_command(printcfg)
+config_cmds.add_command(set_loop)
+config_cmds.add_command(set_port)
+config_cmds.add_command(set_cert_file)
+config_cmds.add_command(set_cert_key)
+config_cmds.add_command(set_cert)
+config_cmds.add_command(enable_ssl)
+config_cmds.add_command(disable_ssl)
+config_cmds.add_command(require_crypto)
+config_cmds.add_command(optional_crypto)
+config_cmds.add_command(enable_handshakes)
+config_cmds.add_command(disable_handshakes)

--- a/hmcli/config/cmd_group.py
+++ b/hmcli/config/cmd_group.py
@@ -1,0 +1,8 @@
+from hmcli.base import hmcli_cmds
+
+
+@hmcli_cmds.group("config", help="HiveMind config helper")
+def config_cmds():
+    """
+    the subcommand 'hivemind config', a Click command group
+    """

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,11 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  local   LocalHive controls
-  listener  HiveMind server controls
-  setup   HiveMind service configuration - Valid options: 'all', 'ovos',...
+  config    HiveMind config helper
+  listener  HiveMind listener controls
+  local     LocalHive controls
+  server    HiveMind server controls
+  setup     HiveMind service configuration - Valid options: 'all', 'ovos',...
 ```
 
 ### Setup
@@ -36,24 +38,38 @@ Commands:
   stop     stop named service for hivemind
 
 ```
+NOTES:
+- install uses pip and installs from github
+- enable creates user systemd services
+- ovos-core is installed, not mycroft
 
-### LocalHive
+### Config
 
 ```bash
-$ hmcli local --help
+$ hmcli config --help
 
-Usage: hmcli local [OPTIONS] COMMAND [ARGS]...
+Usage: hmcli config [OPTIONS] COMMAND [ARGS]...
 
-  LocalHive controls
+  HiveMind config helper
 
 Options:
   --help  Show this message and exit.
 
 Commands:
-  connect-skill    connect a skill to LocalHive
-  load-skills-dir  connect a directory containing skills to LocalHive
-
+  disable-handshake  Disable automatic crypto key negotiation
+  disable-ssl        Disable wss:// (insecure)
+  enable-handshake   Enable automatic crypto key negotiation
+  enable-ssl         Enable wss:// (secure)
+  optional-crypto    optional AES encryption, default to plain text messages
+  print              print json config
+  require-crypto     require AES encryption, connections will be refused if...
+  set-cert-file      set filename for ssl certificate, default HiveMind.crt
+  set-cert-key       set filename for ssl certificate, default HiveMind.key
+  set-cert-path      set path to look for ssl certificates
+  set-loop           set event loop backend
+  set-port           set hivemind listener port
 ```
+NOTE: some of these settings are still open PRs in upstream
 
 ### Listener
 
@@ -88,9 +104,6 @@ Scanning....
 └───────┴──────────┴───────────────┴──────┘
 ```
 
-
-## Credentials Management
-
 ```     
 $ hmcli listener add-device Mark1
 Credentials added to database!
@@ -121,3 +134,21 @@ Access Key: 41c544ecd8f939c2b7125858ce903a08
 Encryption Key: 57f89a205d4d7685
 ```
 
+
+### LocalHive
+
+```bash
+$ hmcli local --help
+
+Usage: hmcli local [OPTIONS] COMMAND [ARGS]...
+
+  LocalHive controls
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  connect-skill    connect a skill to LocalHive
+  load-skills-dir  connect a directory containing skills to LocalHive
+
+```


### PR DESCRIPTION
```bash
$ hmcli config --help

Usage: hmcli config [OPTIONS] COMMAND [ARGS]...

  HiveMind config helper

Options:
  --help  Show this message and exit.

Commands:
  disable-handshake  Disable automatic crypto key negotiation
  disable-ssl        Disable wss:// (insecure)
  enable-handshake   Enable automatic crypto key negotiation
  enable-ssl         Enable wss:// (secure)
  optional-crypto    optional AES encryption, default to plain text messages
  print              print json config
  require-crypto     require AES encryption, connections will be refused if...
  set-cert-file      set filename for ssl certificate, default HiveMind.crt
  set-cert-key       set filename for ssl certificate, default HiveMind.key
  set-cert-path      set path to look for ssl certificates
  set-loop           set event loop backend
  set-port           set hivemind listener port
```
NOTE: some of these settings are still open PRs in upstream
